### PR TITLE
Minor Terminology Fixes

### DIFF
--- a/colcon_hardware_acceleration/subverb/__init__.py
+++ b/colcon_hardware_acceleration/subverb/__init__.py
@@ -110,7 +110,7 @@ def get_subverb_extensions():
 
 def get_workspace_path():
     """
-    Get the path to the current ROS 2 workspace
+    Get the path to the current colcon workspace
 
     :rtype: String
     """
@@ -121,13 +121,13 @@ def get_workspace_path():
         raise FileNotFoundError(
             current_dir,
             "consider running "
-            + "this command from the root directory of the ROS 2 workspace ",
+            + "this command from the root directory of the colcon workspace ",
         )
 
 
 def get_workspace_dir():
     """
-    Get the name to the current ROS 2 workspace
+    Get the name to the current colcon workspace
     :rtype: String
     """
     current_dir = get_workspace_path()
@@ -231,7 +231,7 @@ def get_build_dir():
             build_dir,
             "consider running "
             + "this command from the root directory of the workspace "
-            + "after building the ROS 2 workspace overlay. \n"
+            + "after building the colcon workspace overlay. \n"
             + "Try 'colcon build --merge-install' first.",
         )
 
@@ -287,7 +287,7 @@ def get_platform_dir():
 
 def get_install_dir(install_dir_input="install"):
     """
-    Get the path to the install directory of the current ROS 2 overlay worksapce
+    Get the path to the install directory of the current colcon overlay worksapce
 
     :rtype: String
     """
@@ -633,7 +633,7 @@ def exists(file_path):
         return False
 
 
-def copy_ros2_workspace(install_dir):  # noqa: D102
+def copy_colcon_workspace(install_dir):  # noqa: D102
     """
     Prepare the emulation
 
@@ -660,7 +660,7 @@ def copy_ros2_workspace(install_dir):  # noqa: D102
             + "the workspace first"
         )
         sys.exit(1)
-    green("- Verified that install/ is available in the current ROS 2 workspace")
+    green("- Verified that install/ is available in the current colcon workspace")
 
     #########################
     # 2. mounts the embedded raw image ("sd_card.img" file) available in deployed firmware
@@ -757,7 +757,7 @@ def copy_ros2_workspace(install_dir):  # noqa: D102
     green("- Image mounted successfully at: " + mountpoint)
 
     workspace_dir = get_workspace_dir()
-    # remove prior overlay ROS 2 workspace files at "/<workspace_dir>",
+    # remove prior overlay colcon workspace files at "/<workspace_dir>",
     #  and copy the <ws>/<install_dir> directory as such
     if os.path.exists(mountpoint + "/" + workspace_dir):
         cmd = "sudo rm -r " + mountpoint + "/" + workspace_dir + "/*"
@@ -770,7 +770,7 @@ def copy_ros2_workspace(install_dir):  # noqa: D102
             )
             sys.exit(1)
         green(
-            "- Successfully cleaned up prior overlay ROS 2 workspace "
+            "- Successfully cleaned up prior overlay colcon workspace "
             + "at: "
             + mountpoint
             + "/"
@@ -778,7 +778,7 @@ def copy_ros2_workspace(install_dir):  # noqa: D102
         )
     else:
         yellow(
-            "No prior overlay ROS 2 workspace found "
+            "No prior overlay colcon workspace found "
             + "at: "
             + mountpoint
             + "/"
@@ -789,7 +789,7 @@ def copy_ros2_workspace(install_dir):  # noqa: D102
         outs, errs = run(cmd, shell=True)
         if errs:
             red(
-                "Something went wrong while creating overlay ROS 2 workspace.\n"
+                "Something went wrong while creating overlay colcon workspace.\n"
                 + "Review the output: "
                 + errs
             )
@@ -799,7 +799,7 @@ def copy_ros2_workspace(install_dir):  # noqa: D102
     outs, errs = run(cmd, shell=True)
     if errs:
         red(
-            "Something went wrong while copying overlay ROS 2 workspace to mountpoint.\n"
+            "Something went wrong while copying overlay colcon workspace to mountpoint.\n"
             + "Review the output: "
             + errs
         )
@@ -807,7 +807,7 @@ def copy_ros2_workspace(install_dir):  # noqa: D102
     green(
         "- Copied '"
         + install_dir
-        + "' directory as a ROS 2 overlay workspace in the raw image "
+        + "' directory as a colcon overlay workspace in the raw image "
         + " at location "
         + "/"
         + workspace_dir
@@ -897,10 +897,10 @@ def create_ros2_overlay_script():  # noqa: D102
     content = """
 AMENT_SHELL=bash
 
-# source ROS 2 installation in Yocto-based rootfs
+# source colcon installation in Yocto-based rootfs
 source /usr/bin/ros_setup.bash
 
-# source ROS 2 overlay workspace
+# source colcon overlay workspace
 """
     content += "source /" + workspace_dir + "/local_setup.bash"
 

--- a/colcon_hardware_acceleration/subverb/emulation.py
+++ b/colcon_hardware_acceleration/subverb/emulation.py
@@ -250,7 +250,7 @@ class EmulationSubverb(AccelerationSubverbExtensionPoint):
                 + "the workspace first"
             )
             sys.exit(1)
-        green("- Verified that install/ is available in the current ROS 2 workspace")
+        green("- Verified that install/ is available in the current colcon workspace")
 
         rawimage_path = get_rawimage_path()
         if not rawimage_path:
@@ -358,7 +358,7 @@ class EmulationSubverb(AccelerationSubverbExtensionPoint):
             green("- Image mounted successfully at: " + mountpoint)
 
             workspace_dir = get_workspace_dir()
-            # remove prior overlay ROS 2 workspace files at "/<workspace_dir>",
+            # remove prior overlay colcon workspace files at "/<workspace_dir>",
             #  and copy the <ws>/install directory as such
             if os.path.exists(mountpoint + "/" + workspace_dir):
                 cmd = "sudo rm -r " + mountpoint + "/" + workspace_dir + "/*"
@@ -371,7 +371,7 @@ class EmulationSubverb(AccelerationSubverbExtensionPoint):
                     )
                     sys.exit(1)
                 green(
-                    "- Successfully cleaned up prior overlay ROS 2 workspace "
+                    "- Successfully cleaned up prior overlay colcon workspace "
                     + "at: "
                     + mountpoint
                     + "/"
@@ -379,7 +379,7 @@ class EmulationSubverb(AccelerationSubverbExtensionPoint):
                 )
             else:
                 yellow(
-                    "No prior overlay ROS 2 workspace found "
+                    "No prior overlay colcon workspace found "
                     + "at: "
                     + mountpoint
                     + "/"
@@ -390,7 +390,7 @@ class EmulationSubverb(AccelerationSubverbExtensionPoint):
                 outs, errs = run(cmd, shell=True)
                 if errs:
                     red(
-                        "Something went wrong while creating overlay ROS 2 workspace.\n"
+                        "Something went wrong while creating overlay colcon workspace.\n"
                         + "Review the output: "
                         + errs
                     )
@@ -401,7 +401,7 @@ class EmulationSubverb(AccelerationSubverbExtensionPoint):
             outs, errs = run(cmd, shell=True)
             if errs:
                 red(
-                    "Something went wrong while copying overlay ROS 2 workspace to mountpoint.\n"
+                    "Something went wrong while copying overlay colcon workspace to mountpoint.\n"
                     + "Review the output: "
                     + errs
                 )

--- a/colcon_hardware_acceleration/subverb/hls.py
+++ b/colcon_hardware_acceleration/subverb/hls.py
@@ -36,7 +36,7 @@ class HLSSubverb(AccelerationSubverbExtensionPoint):
 
     NOTE: Default behavior of this subverb is to show the HLS "status"
 
-    Exposes Vitis HLS suite at the colcon ROS 2 meta build tools level. Provides:
+    Exposes Vitis HLS suite at the colcon meta build tools level for ROS 2 packages. Provides:
         0. Capability to show the HLS status of a given ROS 2 package
         1. Capability to launch Tcl scripts (pre-generated with ament macros, e.g. see vitis_hls_generate_tcl)
         2. Capability to bring up summarized versions of synthesis reports
@@ -93,7 +93,7 @@ class HLSSubverb(AccelerationSubverbExtensionPoint):
         if len(filter_data) < 1:
             red(
                 "No build* directories found.\n"
-                + "Make sure you're in the root of your ROS 2 workspace and the build "
+                + "Make sure you're in the root of your colcon workspace and the build "
                 + "dir starts with 'build'."
             )
             sys.exit(1)

--- a/colcon_hardware_acceleration/subverb/hypervisor.py
+++ b/colcon_hardware_acceleration/subverb/hypervisor.py
@@ -21,7 +21,7 @@ from colcon_hardware_acceleration.subverb import (
     replace_kernel,
     add_kernel,
     exists,
-    copy_ros2_workspace,
+    copy_colcon_workspace,
     copy_libstdcppfs
 )
 from colcon_hardware_acceleration.verb import green, yellow, red, gray
@@ -906,7 +906,7 @@ class HypervisorSubverb(AccelerationSubverbExtensionPoint):
 
             # copy ROS workspace to image
             if context.args.install_dir:
-                copy_ros2_workspace(context.args.install_dir)
+                copy_colcon_workspace(context.args.install_dir)
 
         else:
             red("No dom0 specified, doing nothing.")

--- a/colcon_hardware_acceleration/subverb/linux.py
+++ b/colcon_hardware_acceleration/subverb/linux.py
@@ -17,7 +17,7 @@ from colcon_hardware_acceleration.subverb import (
     run,
     mountpoint1,
     exists,
-    copy_ros2_workspace,
+    copy_colcon_workspace,
     copy_libstdcppfs,
 )
 from colcon_hardware_acceleration.verb import green, yellow, red, gray
@@ -493,7 +493,7 @@ class LinuxSubverb(AccelerationSubverbExtensionPoint):
         # copy workspace to image
         #####################
         if context.args.install_dir:
-            copy_ros2_workspace(context.args.install_dir)
+            copy_colcon_workspace(context.args.install_dir)
 
         #####################
         # Fixes in rootfs


### PR DESCRIPTION
Minor terminology fixes renaming ROS 2 to colcon in most cases.

The only major notable change is the function `copy_ros2_workspace()` is renamed to `copy_colcon_workspace()`.

Let me know if it breaks anything!